### PR TITLE
Fix editor's direction bug on RTL websites

### DIFF
--- a/extension/my-style.css
+++ b/extension/my-style.css
@@ -23,4 +23,8 @@
   background: #fcfcfc;
   font: 13px "Inconsolata", "Consolas", "Menlo", "Monaco",
     "Lucida Console", "Courier New", "Courier", monospace;
+	
+  /* Fix editor's direction bug on RTL websites */
+  direction:ltr;
+  text-align:left;
 }


### PR DESCRIPTION
On RTL websites, editor's direction changed automatically to right, i have fixed this issue:
![Screenshot of bug, before fix](https://f.cloud.github.com/assets/1054228/304103/41ebf0f0-9635-11e2-823a-53e614de8ca0.PNG)
